### PR TITLE
Readme updated - To build executable files for GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ Installing as a Windows service
 
 > TODO: fill this section with more info to help Non-Technical Individuals.
 
+## Creating Executable File for GUI
+### Linux:
+1. Activate virtual environment
+1. Inside the root folder run the following   commands:
+    ```
+    pip install pyinstaller
+    ```
+
+    ```
+    python -m PyInstaller --name="attendance-sync-linux" --windowed --onefile gui.py
+    ```
+1. The `attendance-sync-linux` executable file created inside `dist/` folder.
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -93,18 +93,22 @@ Installing as a Windows service
 
 > TODO: fill this section with more info to help Non-Technical Individuals.
 
-## To create executable file for GUI
-### Linux:
+## To build executable file for GUI
+### Linux and Windows:
 1. Activate virtual environment.
-1. Inside the root folder run the following commands:
+1. Navigate to the repository folder (where `gui.py` located) by
+    ```
+    cd biometric-attendance-sync-tool
+    ```
+1. Run the following commands:
     ```
     pip install pyinstaller
     ```
 
     ```
-    python -m PyInstaller --name="attendance-sync-linux" --windowed --onefile gui.py
+    python -m PyInstaller --name="attendance-sync" --windowed --onefile gui.py
     ```
-1. The executable file `attendance-sync-linux` created inside `dist/` folder.
+1. The executable file `attendance-sync` created inside `dist/` folder.
 
 ### Resources
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Installing as a Windows service
 
 > TODO: fill this section with more info to help Non-Technical Individuals.
 
-## Creating Executable File for GUI
+## To create executable file for GUI
 ### Linux:
-1. Activate virtual environment
-1. Inside the root folder run the following   commands:
+1. Activate virtual environment.
+1. Inside the root folder run the following commands:
     ```
     pip install pyinstaller
     ```
@@ -104,7 +104,7 @@ Installing as a Windows service
     ```
     python -m PyInstaller --name="attendance-sync-linux" --windowed --onefile gui.py
     ```
-1. The `attendance-sync-linux` executable file created inside `dist/` folder.
+1. The executable file `attendance-sync-linux` created inside `dist/` folder.
 
 ### Resources
 


### PR DESCRIPTION
This PR updates the readme to build executable files for GUI in both Linux and Windows environments using PyInstaller commands.

### Access executable file inside the dist folder:

![executable](https://user-images.githubusercontent.com/36359901/84521944-67662800-acf3-11ea-92f6-b6b0c192af29.gif)
