### PR TITLE
fix: exit on interrupt

### DIFF
--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -5,11 +5,14 @@ import datetime
 import json
 import os
 import sys
-import time
 import logging
 from logging.handlers import RotatingFileHandler
 import pickledb
 from zk import ZK, const
+
+from threading import Event
+
+exit = Event()
 
 EMPLOYEE_NOT_FOUND_ERROR_MESSAGE = "No Employee found for the given employee field value"
 EMPLOYEE_INACTIVE_ERROR_MESSAGE = "Transactions cannot be created for an Inactive Employee"
@@ -321,12 +324,19 @@ status = pickledb.load('/'.join([config.LOGS_DIRECTORY, 'status.json']), True)
 
 def infinite_loop(sleep_time=15):
     print("Service Running...")
-    while True:
+    while not exit.is_set():
         try:
             main()
-            time.sleep(sleep_time)
+            exit.wait(sleep_time)
         except BaseException as e:
             print(e)
 
+def quit(signo, _frame):
+    print("Interrupted by %d, shutting down" % signo)
+    exit.set()
+
 if __name__ == "__main__":
+    # https://stackoverflow.com/a/46346184
+    for sig in ('TERM', 'HUP', 'INT'):
+        signal.signal(getattr(signal, 'SIG'+sig), quit)
     infinite_loop()


### PR DESCRIPTION
The infinite loop and sleep never listed to interrupts or signals causing it to run forever.
Shutting down my laptop took forever as the process wouldn't stop and had to be timed out.

This PR fixes the same.