### PR TITLE
fix: explicity specify content type and send data as json

### DIFF
--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -182,7 +182,8 @@ def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=No
     url = f"{config.ERPNEXT_URL}/api/method/{endpoint_app}.hr.doctype.employee_checkin.employee_checkin.add_log_based_on_employee_field"
     headers = {
         'Authorization': "token "+ config.ERPNEXT_API_KEY + ":" + config.ERPNEXT_API_SECRET,
-        'Accept': 'application/json'
+        'Accept': 'application/json',
+        'Content-Type': 'application/json'
     }
     data = {
         'employee_field_value' : employee_field_value,
@@ -190,7 +191,7 @@ def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=No
         'device_id' : device_id,
         'log_type' : log_type
     }
-    response = requests.request("POST", url, headers=headers, data=data)
+    response = requests.request("POST", url, headers=headers, json=data)
     if response.status_code == 200:
         return 200, json.loads(response._content)['message']['name']
     else:

--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -182,8 +182,7 @@ def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=No
     url = f"{config.ERPNEXT_URL}/api/method/{endpoint_app}.hr.doctype.employee_checkin.employee_checkin.add_log_based_on_employee_field"
     headers = {
         'Authorization': "token "+ config.ERPNEXT_API_KEY + ":" + config.ERPNEXT_API_SECRET,
-        'Accept': 'application/json',
-        'Content-Type': 'application/json'
+        'Accept': 'application/json'
     }
     data = {
         'employee_field_value' : employee_field_value,


### PR DESCRIPTION
This would be the appropriate fix for: https://github.com/frappe/hrms/pull/1025

Weirdly, so far, the script has worked fine for a lot of people while it used to fail randomly with error as such: https://github.com/frappe/hrms/issues/441

Setting the Content-Type should fix the issue.