### PR TITLE
fix: 'pickledb' has no attribute 'loads' issue fixed

### DIFF
--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -8,7 +8,7 @@ import sys
 import time
 import logging
 from logging.handlers import RotatingFileHandler
-import pickledb
+from pickledb import PickleDB
 from zk import ZK, const
 
 EMPLOYEE_NOT_FOUND_ERROR_MESSAGE = "No Employee found for the given employee field value"
@@ -317,7 +317,7 @@ if not os.path.exists(config.LOGS_DIRECTORY):
     os.makedirs(config.LOGS_DIRECTORY)
 error_logger = setup_logger('error_logger', '/'.join([config.LOGS_DIRECTORY, 'error.log']), logging.ERROR)
 info_logger = setup_logger('info_logger', '/'.join([config.LOGS_DIRECTORY, 'logs.log']))
-status = pickledb.load('/'.join([config.LOGS_DIRECTORY, 'status.json']), True)
+status = PickleDB('/'.join([config.LOGS_DIRECTORY, 'status.json']))
 
 def infinite_loop(sleep_time=15):
     print("Service Running...")


### PR DESCRIPTION
python - 3.8+

Installed Apps
ERPNext: v15.49.2 (version-15)
Frappe Framework: v15.53.0 (version-15)
Frappe HR: v15.38.1 (version-15)

while try to run erpnext_sync.py script "pickledb  - loads no attricute issue raise"
(venv) barath@barath-Latitude-7490:~/Documents/biometric-attendance-sync-tool$ python3 erpnext_sync.py 
Traceback (most recent call last):
  File "/home/barath/Documents/biometric-attendance-sync-tool/erpnext_sync.py", line 320, in <module>
    status = pickledb.loads('/'.join([config.LOGS_DIRECTORY, 'status.json']), True)
             ^^^^^^^^^^^^^^
AttributeError: module 'pickledb' has no attribute 'loads'
