### PR TITLE
fix: Install a previous version of pickleDB

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 requests
-pickledb
+pickledb==0.9
 pyzk
 PyQt5


### PR DESCRIPTION
#### Problem
PickeDB recently went through a major rewrite [that isn't backwards compatible](https://github.com/patx/pickledb/blob/master/README.md#key-improvements-in-version-10), which throws`module pickledb has no attribute load` error

### Fix
Specified previous version 0.9 in requirements.txt
