### PR TITLE
feat: allow sending device co-ordinates to Frappe HR

### DIFF
--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -180,7 +180,7 @@ def get_all_attendance_from_device(ip, port=4370, timeout=30, device_id=None, cl
 
 def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=None, latitude=None, longitude=None):
     """
-    Example: send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN')
+    Example: send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN',latitude=12.34, longitude=56.78)
     """
     endpoint_app = "hrms" if ERPNEXT_VERSION > 13 else "erpnext"
     url = f"{config.ERPNEXT_URL}/api/method/{endpoint_app}.hr.doctype.employee_checkin.employee_checkin.add_log_based_on_employee_field"

--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -128,7 +128,7 @@ def pull_process_and_push_data(device, device_attendance_logs=None):
                 punch_direction = 'IN'
             else:
                 punch_direction = None
-        erpnext_status_code, erpnext_message = send_to_erpnext(device_attendance_log['user_id'], device_attendance_log['timestamp'], device['device_id'], punch_direction)
+        erpnext_status_code, erpnext_message = send_to_erpnext(device_attendance_log['user_id'], device_attendance_log['timestamp'], device['device_id'], punch_direction, latitude=device['latitude'], longitude=device['longitude'])
         if erpnext_status_code == 200:
             attendance_success_logger.info("\t".join([erpnext_message, str(device_attendance_log['uid']),
                 str(device_attendance_log['user_id']), str(device_attendance_log['timestamp'].timestamp()),
@@ -178,7 +178,7 @@ def get_all_attendance_from_device(ip, port=4370, timeout=30, device_id=None, cl
     return list(map(lambda x: x.__dict__, attendances))
 
 
-def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=None):
+def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=None, latitude=None, longitude=None):
     """
     Example: send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN')
     """
@@ -192,7 +192,9 @@ def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=No
         'employee_field_value' : employee_field_value,
         'timestamp' : timestamp.__str__(),
         'device_id' : device_id,
-        'log_type' : log_type
+        'log_type' : log_type,
+        'latitude' : latitude,
+        'longitude' : longitude
     }
     response = requests.request("POST", url, headers=headers, json=data)
     if response.status_code == 200:

--- a/erpnext_sync.py
+++ b/erpnext_sync.py
@@ -180,7 +180,14 @@ def get_all_attendance_from_device(ip, port=4370, timeout=30, device_id=None, cl
 
 def send_to_erpnext(employee_field_value, timestamp, device_id=None, log_type=None, latitude=None, longitude=None):
     """
-    Example: send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN',latitude=12.34, longitude=56.78)
+    Examples: 
+    
+    For ERPNext, Frappe HR <= v14
+    send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN')
+
+    For ERPNext, Frappe HR v15 onwards
+    If 'Allow Geolocation Tracking' is on
+    send_to_erpnext('12349',datetime.datetime.now(),'HO1','IN',latitude=12.34, longitude=56.78)
     """
     endpoint_app = "hrms" if ERPNEXT_VERSION > 13 else "erpnext"
     url = f"{config.ERPNEXT_URL}/api/method/{endpoint_app}.hr.doctype.employee_checkin.employee_checkin.add_log_based_on_employee_field"

--- a/local_config.py.template
+++ b/local_config.py.template
@@ -11,15 +11,17 @@ PULL_FREQUENCY = 60 # in minutes
 LOGS_DIRECTORY = 'logs' # logs of this script is stored in this directory
 IMPORT_START_DATE = None # format: '20190501'
 
-# Biometric device configs (all keys mandatory)
+# Biometric device configs (all keys mandatory, except latitude and longitude they are mandatory only if 'Allow Geolocation Tracking' is turned on in Frappe HR)
     #- device_id - must be unique, strictly alphanumerical chars only. no space allowed.
     #- ip - device IP Address
     #- punch_direction - 'IN'/'OUT'/'AUTO'/None
     #- clear_from_device_on_fetch: if set to true then attendance is deleted after fetch is successful.
                                     #(Caution: this feature can lead to data loss if used carelessly.)
+    #- latitude - float, latitude of the location of the device
+    #- longitude - float, longitude of the location of the device
 devices = [
-    {'device_id':'test_1','ip':'192.168.0.209', 'punch_direction': None, 'clear_from_device_on_fetch': False},
-    {'device_id':'test_2','ip':'192.168.2.209', 'punch_direction': None, 'clear_from_device_on_fetch': False}
+    {'device_id':'test_1','ip':'192.168.0.209', 'punch_direction': None, 'clear_from_device_on_fetch': False, 'latitude':0.0000,'longitude':0.0000},
+    {'device_id':'test_2','ip':'192.168.2.209', 'punch_direction': None, 'clear_from_device_on_fetch': False, 'latitude':0.0000,'longitude':0.0000}
 ]
 
 # Configs updating sync timestamp in the Shift Type DocType 


### PR DESCRIPTION
If 'Allow Geolocation Tracking' is turned on in Frappe HR, latitude and longitude fields become mandatory in employee checkins. The API was configured to accept the co-ordinates recently with frappe/hrms#2900 but this tool needs to be able to send them, which is it does now. 